### PR TITLE
Grammatical fixes, gitignore expansion, issue workflow improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-function.md
+++ b/.github/ISSUE_TEMPLATE/add-new-function.md
@@ -13,9 +13,9 @@ The instructions about defining the file's name are documented in the `CONTRIBUT
 
 
 ## Description
-Function name: example `phpversion()`
+Function name: `phpversion()`
 Function description: ...
-File name: example `src/content/docs/01-system/01-sys-phpversion.md`
+File name: `src/content/docs/01-system/01-sys-phpversion.md`
 
 ## Checklist
 - [ ] create the file with the proper name

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 # generated types
 .astro/
 .vscode/
+.idea/
 
 # dependencies
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The functions are grouped into topics:
 Each function is explained with the description, and examples in markdown files in the `src/content/docs` directory.
 
 ## The file name convention
-We have all the Markdown files in the `src/content/docs` directory where you can find the folders for each topic (`00-intro`, `01-system`, `02-array`, etc.
+We have all the Markdown files in the `src/content/docs` directory where you can find the folders for each topic (`00-intro`, `01-system`, `02-array`, etc.)
 Each topic ( Intro, System, Array) has a specific folder with the format
 
 - 2 digits (00 , 01) as topic identifier (progressive number)


### PR DESCRIPTION
- Added missing parenthesis in `CONTRIBUTING.md`
- Added `.idea` folder to `.gitignore` for contributors that use IntelliJ IDEs (e.g. PHPStorm)
- Removed the "example" word from the issue template as it seems to create unnecessary confusion (repository author forgets to remove it when creates a new issue, see issues listed below)
  - https://github.com/roberto-butti/some-drops-of-php/issues/47
  - https://github.com/roberto-butti/some-drops-of-php/issues/39
  - https://github.com/roberto-butti/some-drops-of-php/issues/35
  - https://github.com/roberto-butti/some-drops-of-php/issues/34